### PR TITLE
Make Link not assume Language; Remove confusing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Purple Adblock is an adblocker for Twitch which is available on [Firefox](https:
 3. Click on `Load Temporary Add-on...` and select the `manifest.json` file from the extension folder.
 4. Done! The extension is now installed.
 
-The extension will be removed when you close the browser. To install it permanently, you should download it from the [Firefox Add-ons page](https://addons.mozilla.org/en-US/firefox/addon/purpleadblock/) or using the zip asigned in the release page.
+The extension will be removed when you close the browser. To install it permanently, you should download it from the [Firefox Add-ons page](https://addons.mozilla.org/firefox/addon/purpleadblock/).
 
 ### Chrome
 


### PR DESCRIPTION
The previous link took you to the en_US version of the extension page regardless of your region, the new one will take you to the localized one. I also removed a confusing bit of text that I couldn't work out the meaning of.

## What does this PR do?

- [ ] Adds or edits a feature
- [ ] Fixes a bug
- [ ] Edits config files
- [x] Something else

## Things to check

- [x] Have you tested changes locally?
- [ ] Have you ensured TypeScript compiles?
- [ ] Have you ensured the code is formatted and linted with `npm run lint`?

## Notes
<!-- Change the following as needed; These are just templates -->
- [ ] New dependencies added
- [ ] Unsure of functionality
- [x] etc etc.

## Description

Changes the URL for the firefox extension to be culture independent, and removes a confusing bit of text about permanently installing from the zip... I think. I wasn't exactly clear and honestly will just lead to confusion; Pointing at the store is just simpler for everyone involved. If you're running a fork of Firefox where you can't do that, you probably already know what the correct procedure is.

Fixed #98 